### PR TITLE
Make message banner waste less space

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
       }
       /* Style for the contact message */
       .message {
-        padding: 1rem;
         text-align: center;
         background: #f9f9f9;
         border-bottom: 1px solid #ccc;


### PR DESCRIPTION
Since `<p>` already has padding, it seems like the `1rem` padding around it is a little excessive

Before:
![Screenshot_20250308_023717](https://github.com/user-attachments/assets/fda023b9-00d1-43a6-b01e-a922404c5989)



After:

![Screenshot_20250308_023713](https://github.com/user-attachments/assets/01ae9540-b5cd-4b06-bf44-e0d752b96384)




