### PR TITLE
add github link in the form banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <div class="message">
       <p>
         This is a new version of the form, please contact
-        <a href="mailto:urbanism@rit.edu">urbanism@rit.edu</a> if you have issues!
+        <a href="mailto:urbanism@rit.edu">urbanism@rit.edu</a> or <a href="https://github.com/cbindev/businfo">submit a report</a> if you have issues!
       </p>
     </div>
     <iframe


### PR DESCRIPTION
Figure this may be useful as the site expands, especially as more things get added to the site and people start noticing issues (i.e. if theres a new bus route for spring break)